### PR TITLE
Change date format of <CreDtTm> node

### DIFF
--- a/SEPASDD.php
+++ b/SEPASDD.php
@@ -103,7 +103,7 @@ class SEPASDD {
         
         //Set the values for the nodes
         $MsgIdNode->nodeValue = $this->makeMsgId();
-        $CreDtTmNode->nodeValue = date("c");
+        $CreDtTmNode->nodeValue = date('Y-m-d\TH:i:s', time());
 
        //If using lower than PHP 5.4.0, there is no ENT_XML1
         if( version_compare(PHP_VERSION, '5.4.0') >= 0){


### PR DESCRIPTION
The validation tool in Swift gives the following error:

> Rule "Usage Rabobank: Creation Date Time"
> 
> Only the following format will be accepted: YYYY-MM-DDThh:mm:ss Example: 2014-12-28T11:59:01
> 
> CreationDateTime3 (based on dateTime)
> pattern: [0-9]{4}[-][0-9]{2,2}[-][0-9]{2,2}[T][0-9]{2,2}[:][0-9]{2,2}[:][0-9]{2,2}

The files are accepted by the bank but I don't like the validation errors, also the [specifications](https://www.rabobank.com/en/images/format_description_xml_sepa_credit_transfer.pdf) published by the bank uses the datetime format without timezone.

This PR changes the format from <CreDtTM> from `<CreDtTm>2016-01-08T23:43:08+1:00</CreDtTm>` to `<CreDtTm>2016-01-08T23:43:08</CreDtTm>`

Fixes #25